### PR TITLE
Replace glob with walkdir for significant speed up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,3 @@
-[root]
-name = "alt"
-version = "2.4.0"
-dependencies = [
- "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.5.2"
@@ -17,13 +7,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "argparse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "alt"
+version = "2.4.0"
+dependencies = [
+ "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
-name = "glob"
-version = "0.2.11"
+name = "argparse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -71,6 +66,14 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "same-file"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,27 +96,58 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b3fb52b09c1710b961acb35390d514be82e4ac96a9969a8e38565a29b878dc9"
 "checksum argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37bb99f5e39ee8b23b6e227f5b8f024207e8616f44aa4b8c76ecd828011667ef"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "39dfaaa0f4da0f1a06876c5d94329d739ad0150868069cc235f1ddf80a0480e7"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"
 "checksum regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31040aad7470ad9d8c46302dcffba337bb4289ca5da2e3cd6e37b64109a85199"
+"checksum same-file 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3257af0472da4b8b8902102a57bafffd9991f0f43772a8af6153d597e6e4ae2"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55dd963dbaeadc08aa7266bf7f91c3154a7805e32bb94b820b769d2ef3b4744d"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b6d201f4f8998a837196b6de9c73e35af14c992cbb92c4ab641d2c2dce52de"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "890b38836c01d72fdb636d15c9cfc52ec7fd783b330abc93cd1686f4308dfccc"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
+"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ authors = [ "Andrew De Ponte <cyphactor@gmail.com>", "Brian Miller <brimil01@gma
 [dependencies]
 
 argparse = "0.2.1"
-glob = "0.2.11"
+walkdir = "2.0.1"
 regex = "0.1.73"
 lazy_static = "0.2"

--- a/src/alt/path/alteration/mod.rs
+++ b/src/alt/path/alteration/mod.rs
@@ -2,11 +2,11 @@ extern crate regex;
 
 use self::regex::Regex;
 
-pub fn strip_test_words(filename: &String) -> String {
+pub fn strip_test_words(filename: &str) -> &str {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"(test_)?(?P<p>\w+?)(_rake_spec|_spec|_rake_test|_test|_steps|Tests|UITests|Specs|UISpecs|Test|Spec|Suite)?(\.\w+)?$").unwrap();
     }
-    RE.replace_all(filename.as_str(), "$p")
+    RE.captures(filename).and_then(|caps| caps.name("p")).unwrap_or(filename)
 }
 
 #[cfg(test)]

--- a/src/alt/path/classification/mod.rs
+++ b/src/alt/path/classification/mod.rs
@@ -2,11 +2,11 @@ extern crate regex;
 
 use self::regex::Regex;
 
-pub fn is_test_file(path: &String) -> bool {
+pub fn is_test_file(path: &str) -> bool {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"^(features/step_definitions/|test/|spec/|tests/|src/test/|\w*Tests/)").unwrap();
     }
-    RE.is_match(path.as_str())
+    RE.is_match(path)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ macro_rules! printerr(
 
 struct Options {
     path: String,
-    file: Option<String>
+    possible_alternates_path: Option<String>
 }
 
 fn is_hidden(entry: &DirEntry) -> bool {
@@ -132,13 +132,13 @@ fn find_alt(filename: &String, cleansed_path: &String, paths: Vec<String>, test_
 fn main() {
     let mut options = Options {
         path: "".to_string(),
-        file: None
+        possible_alternates_path: None
     };
 
     { // block limits of borrows by refer() method calls
         let mut ap = ArgumentParser::new();
         ap.add_option(&["-v", "--version"], Print(env!("CARGO_PKG_VERSION").to_string()), "show version");
-        ap.refer(&mut options.file).add_option(&["-f", "--file"], StoreOption, "possible alternates file, - for stdin");
+        ap.refer(&mut options.possible_alternates_path).add_option(&["-f", "--file"], StoreOption, "possible alternates file, - for stdin");
         ap.refer(&mut options.path).add_argument("PATH", Store, "path to find alternate for").required();
         ap.parse_args_or_exit();
     }
@@ -149,7 +149,7 @@ fn main() {
         filename = alt::path::alteration::strip_test_words(&filename);
     }
 
-    let best_match = if let Some(unwrapped_file) = options.file {
+    let best_match = if let Some(unwrapped_file) = options.possible_alternates_path {
         if unwrapped_file == "-" {
             let stdin = std::io::stdin();
             let paths: Vec<String> = stdin.lock().lines().map(|path| path.unwrap()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn find_alt(filename: &String, cleansed_path: &String, paths: Vec<String>, test_
     alternate
 }
 
-fn main() {
+fn parse_args_or_exit() -> Options {
     let mut options = Options {
         path: "".to_string(),
         possible_alternates_path: None
@@ -142,6 +142,12 @@ fn main() {
         ap.refer(&mut options.path).add_argument("PATH", Store, "path to find alternate for").required();
         ap.parse_args_or_exit();
     }
+
+    options
+}
+
+fn main() {
+    let options = parse_args_or_exit();
 
     let cleansed_path = cleanse_path(&options.path);
     let mut filename = get_filename_minus_extension(&options.path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,17 +205,17 @@ mod tests {
 
     #[test]
     fn cleanse_path_returns_path_with_dot_slash_prefix_stripped() {
-        assert_eq!("hoopty/doopty.thing",cleanse_path("./hoopty/doopty.thing"));
+        assert_eq!("hoopty/doopty.thing", cleanse_path("./hoopty/doopty.thing"));
     }
 
     #[test]
     fn cleanse_path_does_not_effect_non_dot_slash_prefixes() {
-        assert_eq!("foo/hoopty/doopty.thing",cleanse_path("foo/hoopty/doopty.thing"));
+        assert_eq!("foo/hoopty/doopty.thing", cleanse_path("foo/hoopty/doopty.thing"));
     }
 
     #[test]
     fn get_filename_minus_extension_returns_the_filename_without_the_extension() {
-        let s = String::from("foo/hoopty/doopty.thing");
-        assert_eq!("doopty", get_filename_minus_extension(&s));
+        let s = "foo/hoopty/doopty.thing";
+        assert_eq!("doopty", get_filename_minus_extension(s));
     }
 }


### PR DESCRIPTION
This PR replaces the use of glob with walkdir. On my work machine this makes finding alternate files in our codebase go from ~985ms to 6ms. Additionally I cleaned up the code to use fewer heap allocated Strings, instead favouring slices and `str` references. This also yeided some speed ups as shown in the the benchmark results below.

## Benchmarks

### Original

```
Rust Classic Implementation
                      user     system      total        real
For impl. file:   0.060000   0.100000  10.120000 (  9.239286)
For test file:    0.050000   0.070000   9.200000 (  8.550415)

Rust Classic Implementation - Discourse
                      user     system      total        real
For impl. file:   0.040000   0.100000  10.410000 (  9.532837)
For test file:    0.070000   0.070000  12.010000 ( 11.188782)
```

### walkdir

```
Rust Classic Implementation
                      user     system      total        real
For impl. file:   0.070000   0.060000   6.040000 (  5.301172)
For test file:    0.060000   0.070000   7.780000 (  7.051830)

Rust Classic Implementation - Discourse
                      user     system      total        real
For impl. file:   0.070000   0.080000   7.730000 (  6.825507)
For test file:    0.080000   0.080000  11.080000 ( 10.052113)
```
