### PR TITLE
Add option to strip words when the file contains .spec

### DIFF
--- a/src/alt/path/alteration/mod.rs
+++ b/src/alt/path/alteration/mod.rs
@@ -4,7 +4,7 @@ use self::regex::Regex;
 
 pub fn strip_test_words(filename: &str) -> &str {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r"(test_)?(?P<p>\w+?)(_rake_spec|_spec|_rake_test|_test|_steps|.test|Tests|UITests|Specs|UISpecs|Test|Spec|Suite)?(\.\w+)?$").unwrap();
+        static ref RE: Regex = Regex::new(r"(test_)?(?P<p>\w+?)(_rake_spec|_spec|_rake_test|_test|_steps|.test|.spec|Tests|UITests|Specs|UISpecs|Test|Spec|Suite)?(\.\w+)?$").unwrap();
     }
     RE.captures(filename).and_then(|caps| caps.name("p")).map(|m| m.as_str()).unwrap_or(filename)
 }
@@ -95,6 +95,20 @@ mod tests {
     fn strip_test_words_returns_filename_with_elixer_exunit_test_words_stripped() {
         let s = String::from("supervisor_test.exs");
         assert_eq!(strip_test_words(&s), "supervisor");
+    }
+
+    // React JSX extension
+
+    #[test]
+    fn strip_test_words_returns_filename_with_jsx_test_words_stripped() {
+        let s = String::from("jacked.spec.jsx");
+        assert_eq!(strip_test_words(&s), "jacked");
+    }
+
+    #[test]
+    fn strip_test_words_returns_filename_with_jsx_words_stripped() {
+        let s = String::from("jacked.jsx");
+        assert_eq!(strip_test_words(&s), "jacked");
     }
 
     // JavaScript Jasmine

--- a/src/alt/path/classification/mod.rs
+++ b/src/alt/path/classification/mod.rs
@@ -344,6 +344,19 @@ mod tests {
         let s = String::from("src/foo/bar/jacked.spec.js");
         assert_eq!(is_test_file(&s), true);
     }
+
+    #[test]
+    fn is_test_file_detects_jsx_jest_test_files_in_src_directory() {
+        let s = String::from("src/components/foo/bar/index.spec.jsx");
+        assert_eq!(is_test_file(&s), true);
+    }
+
+    #[test]
+    fn is_test_file_does_not_detects_jsx_files_in_src_directory() {
+        let s = String::from("src/components/foo/bar/index.jsx");
+        assert_eq!(is_test_file(&s), false);
+    }
+
     // Python
 
     #[test]


### PR DESCRIPTION
This small PR includes a simple change on the `strip_test_words` to strip correctly the file name with `.spec.jsx`. example: `index.spec.jsx`.
Also includes some specs on classification to cover the files with `jsx|.spec.jsx`.