### PR TITLE
Add support for foo_test.go file types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "alt"
-version = "3.3.0"
+version = "3.3.1"
 authors = [ "Drew De Ponte <cyphactor@gmail.com>", "Brian Miller <brimil01@gmail.com>", "Russ Cloak <russcloak@gmail.com>" ]
 
 [dependencies]

--- a/src/alt/path/alteration/mod.rs
+++ b/src/alt/path/alteration/mod.rs
@@ -6,7 +6,10 @@ pub fn strip_test_words(filename: &str) -> &str {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"(test_)?(?P<p>\w+?)(_rake_spec|_spec|_rake_test|_test|_steps|.test|.spec|Tests|UITests|Specs|UISpecs|Test|Spec|Suite)?(\.\w+)?$").unwrap();
     }
-    RE.captures(filename).and_then(|caps| caps.name("p")).map(|m| m.as_str()).unwrap_or(filename)
+    RE.captures(filename)
+        .and_then(|caps| caps.name("p"))
+        .map(|m| m.as_str())
+        .unwrap_or(filename)
 }
 
 #[cfg(test)]
@@ -161,5 +164,12 @@ mod tests {
     fn strip_test_words_returns_filename_with_scalatest_suite_word_stripped() {
         let s = String::from("SomethingSuite.scala");
         assert_eq!(strip_test_words(&s), "Something");
+    }
+
+    // Go
+    #[test]
+    fn strip_test_words_returns_filename_with_go_test_words_stripped() {
+        let s = String::from("foo_test.go");
+        assert_eq!(strip_test_words(&s), "foo");
     }
 }


### PR DESCRIPTION
This fixes #26 

`alt` mostly supported go tests out of the box. It already was stripping `_test` from test files. The issue was it couldn't handle test files in the same directory.

This required modifying the regexp. This was getting pretty big and complex, so I broke it up and commented it at the same time. At least I commented it with what I think it does. The comments should be double checked for accuracy.

Cheers!

```
$ ls
foo.go      foo_test.go
$ alt foo.go
foo_test.go%
```